### PR TITLE
Slow down winter changes by default and add the ability to control the changes with 'nexuses'

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,2 @@
 default
+caverealms?

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,3 @@
 name = holidays
 depends = default
+optional_depends = caverealms

--- a/winter.lua
+++ b/winter.lua
@@ -68,9 +68,13 @@ minetest.register_node("holidays:christmas_nexus", {
     end
 })
 
+local humbug_tiles = {"default_coal_block.png^default_mineral_coal.png"}
+if minetest.get_modpath("caverealms") then
+    table.insert(humbug_tiles, "caverealms_coal_dust.png^default_mineral_coal.png")
+end
 minetest.register_node("holidays:humbug_nexus", {
     description = "Humbug Nexus",
-    tiles = {"default_coal_block.png^default_mineral_coal.png","caverealms_coal_dust.png^default_mineral_coal.png"},
+    tiles = humbug_tiles,
     is_ground_content = false,
     groups = {oddly_breakable_by_hand=3},
     sounds = default.node_sound_stone_defaults(),

--- a/winter.lua
+++ b/winter.lua
@@ -27,17 +27,101 @@ minetest.register_node("holidays:dirt_with_snow", {
     }),
 })
 
+local registered_christmas_nexuses = {}
+local registered_humbug_nexuses = {}
+local effect_radius = 25
+
+local function in_range_of_nexus(nexus, pos)
+    if math.abs(nexus.y - pos.y) > effect_radius then
+        return false
+    end
+    if math.abs(nexus.x - pos.x) > effect_radius then
+        return false
+    end
+    if math.abs(nexus.z - pos.z) > effect_radius then
+        return false
+    end
+    return true
+end
+local function in_range_of_nexuses(nexuses, pos)
+    for _,nexus in pairs(nexuses) do
+        if in_range_of_nexus(nexus, pos) then
+            return true
+        end
+    end
+    return false
+end
+
+minetest.register_node("holidays:christmas_nexus", {
+    description = "Christmas Nexus",
+    tiles = {"christmas_chest_top.png"},
+    is_ground_content = false,
+    groups = {oddly_breakable_by_hand=3},
+    sounds = default.node_sound_wood_defaults(),
+    on_construct = function(pos)
+        local key = minetest.pos_to_string(pos)
+        registered_christmas_nexuses[key] = pos
+    end,
+    on_destruct = function(pos)
+        local key = minetest.pos_to_string(pos)
+        registered_christmas_nexuses[key] = nil
+    end
+})
+
+minetest.register_node("holidays:humbug_nexus", {
+    description = "Humbug Nexus",
+    tiles = {"default_coal_block.png^default_mineral_coal.png","caverealms_coal_dust.png^default_mineral_coal.png"},
+    is_ground_content = false,
+    groups = {oddly_breakable_by_hand=3},
+    sounds = default.node_sound_stone_defaults(),
+    on_construct = function(pos)
+        local key = minetest.pos_to_string(pos)
+        registered_humbug_nexuses[key] = pos
+    end,
+    on_destruct = function(pos)
+        local key = minetest.pos_to_string(pos)
+        registered_humbug_nexuses[key] = nil
+    end
+})
+
 
 if holidays.is_holiday_active("winter") then
-    -- ABM to convert surface water to ice
+
+    -- Register any nexuses that are loaded
+    minetest.register_lbm({
+        label = "Register Holiday Nexuses",
+        name = "holidays:register_nexuses",
+        nodenames = {"holidays:christmas_nexus","holidays:humbug_nexus"},
+        run_at_every_load = true,
+        action = function(pos, node)
+            if node.name == "holidays:christmas_nexus" then
+                local key = minetest.pos_to_string(pos)
+                if not registered_christmas_nexuses[key] then
+                    registered_christmas_nexuses[key] = pos
+                end
+            elseif node.name == "holidays:humbug_nexus" then
+                local key = minetest.pos_to_string(pos)
+                if not registered_humbug_nexuses[key] then
+                    registered_humbug_nexuses[key] = pos
+                end
+            end
+        end,
+    })
+
+    -- Create ice & snow like before, but only if there's a christmas nexus and no humbug nexus
     minetest.register_abm({
         label = "Place Holiday Ice",
         nodenames = {"default:water_source"},
         neighbors = {"air"},
         interval = 2.1,
-        chance = 5,
+        chance = 7,
         catch_up = false,
         action = function(pos)
+            if not in_range_of_nexuses(registered_christmas_nexuses, pos)
+               or in_range_of_nexuses(registered_humbug_nexuses, pos)
+            then
+                return
+            end
             if pos.y > 0 then
                 minetest.set_node(pos, {name = "holidays:ice"})
             end
@@ -48,12 +132,106 @@ if holidays.is_holiday_active("winter") then
         nodenames = {"default:dirt_with_grass"},
         neighbors = {"air"},
         interval = 2.3,
-        chance = 5,
+        chance = 7,
         catch_up = false,
         action = function(pos)
+            if not in_range_of_nexuses(registered_christmas_nexuses, pos)
+               or in_range_of_nexuses(registered_humbug_nexuses, pos)
+            then
+                return
+            end
             minetest.set_node(pos, {name = "holidays:dirt_with_snow"})
         end
     })
+
+    -- Remove ice and snow if there's a humbug nexus
+    minetest.register_abm({
+        label = "Remove Holiday Ice",
+        nodenames = {"holidays:ice"},
+        interval = 1.1,
+        chance = 5,
+        catch_up = false,
+        action = function(pos)
+            if not in_range_of_nexuses(registered_humbug_nexuses, pos) then
+                return
+            end
+            minetest.set_node(pos, {name = "default:water_source"})
+        end
+    })
+    minetest.register_abm({
+        label = "Remove Holiday Dirt",
+        nodenames = {"holidays:dirt_with_snow"},
+        interval = 1.3,
+        chance = 5,
+        catch_up = false,
+        action = function(pos)
+            if not in_range_of_nexuses(registered_humbug_nexuses, pos) then
+                return
+            end
+            minetest.set_node(pos, {name = "default:dirt_with_grass"})
+        end
+    })
+
+    -- Spread ice and snow from existing ice and snow, unless there is a humbug nexus
+    -- Copied and modified from https://github.com/Ezhh/caverealms_lite/blob/master/plants.lua
+    minetest.register_abm({
+        label = "Holiday Ice Spread",
+        nodenames = {
+            "holidays:ice",
+            "default:ice",
+        },
+        neighbors = {"air"},
+        interval = 10,
+        chance = 10,
+        catch_up = false,
+        action = function(pos, node)
+            if in_range_of_nexuses(registered_humbug_nexuses, pos) then
+                return
+            end
+            local num = minetest.find_nodes_in_area_under_air(
+                {x = pos.x - 1, y = pos.y - 2, z = pos.z - 1},
+                {x = pos.x + 1, y = pos.y + 1, z = pos.z + 1},
+                "default:water_source")
+            if #num > 0 then
+                local chosen = num[math.random(#num)]
+                if in_range_of_nexuses(registered_humbug_nexuses, chosen) then
+                    return
+                end
+                minetest.set_node(chosen, {name = "holidays:ice"})
+            end
+        end,
+    })
+    minetest.register_abm({
+        label = "Holiday Snow Spread",
+        nodenames = {
+            "holidays:ice",
+            "holidays:dirt_with_snow",
+            "default:ice",
+            "default:snowblock",
+            "default:dirt_with_snow",
+        },
+        neighbors = {"air"},
+        interval = 10,
+        chance = 10,
+        catch_up = false,
+        action = function(pos, node)
+            if in_range_of_nexuses(registered_humbug_nexuses, pos) then
+                return
+            end
+            local num = minetest.find_nodes_in_area_under_air(
+                {x = pos.x - 1, y = pos.y - 2, z = pos.z - 1},
+                {x = pos.x + 1, y = pos.y + 1, z = pos.z + 1},
+                "default:dirt_with_grass")
+            if #num > 0 then
+                local chosen = num[math.random(#num)]
+                if in_range_of_nexuses(registered_humbug_nexuses, chosen) then
+                    return
+                end
+                minetest.set_node(chosen, {name = "holidays:dirt_with_snow"})
+            end
+        end,
+    })
+
 
     minetest.register_craft({
         output = "bucket:bucket_river_water",
@@ -86,7 +264,7 @@ else
         label = "Remove Holiday Ice",
         nodenames = {"holidays:ice"},
         interval = 1.1,
-        chance = 10,
+        chance = 5,
         catch_up = false,
         action = function(pos)
             minetest.set_node(pos, {name = "default:water_source"})
@@ -96,7 +274,7 @@ else
         label = "Remove Holiday Dirt",
         nodenames = {"holidays:dirt_with_snow"},
         interval = 1.3,
-        chance = 10,
+        chance = 5,
         catch_up = false,
         action = function(pos)
             minetest.set_node(pos, {name = "default:dirt_with_grass"})

--- a/winter.lua
+++ b/winter.lua
@@ -32,13 +32,13 @@ local registered_humbug_nexuses = {}
 local effect_radius = 25
 
 local function in_range_of_nexus(nexus, pos)
-    if math.abs(nexus.y - pos.y) > effect_radius then
-        return false
-    end
     if math.abs(nexus.x - pos.x) > effect_radius then
         return false
     end
     if math.abs(nexus.z - pos.z) > effect_radius then
+        return false
+    end
+    if math.abs(nexus.y - pos.y) > effect_radius then
         return false
     end
     return true


### PR DESCRIPTION
Add "christmas nexus" and "humbug nexus" that control the winter changes.

The humbug nexus prevents all winter spread in the area around it (radius 25)
The christmas nexus allows the previous winter behaviour in the area around it (radius 25)

Outside of these nexuses, the behaviour has been changed to spread ice and snow from existing ice & snow sources

This means that people's builds will not be ruined against their will, christmas still has a magical effect for those unaware of the nexuses, and those who like the old behaviour have a way to activate it.

This also stops farm water freezing unless you want it too do so.

I suggest we add these nexuses to a christmas shop for a nominal trade, allowing players to trade them back for the same price.

Fixes https://github.com/BlockySurvival/issue-tracker/issues/359